### PR TITLE
fix: improve error handling for code generation API 500 errors

### DIFF
--- a/worker/agents/planning/blueprint.ts
+++ b/worker/agents/planning/blueprint.ts
@@ -255,7 +255,7 @@ export async function generateBlueprint({ env, inferenceContext, query, language
         //     reasoningEffort = undefined;
         // }
 
-        const { object: results } = await executeInference({
+        const inferenceResult = await executeInference({
             env,
             messages,
             agentActionName: "blueprint",
@@ -263,6 +263,14 @@ export async function generateBlueprint({ env, inferenceContext, query, language
             context: inferenceContext,
             stream: stream,
         });
+
+        // Validate inference result - executeInference can return null on failure
+        if (!inferenceResult) {
+            logger.error('Blueprint inference failed after all retries');
+            throw new Error('Blueprint generation failed after multiple attempts. Please try again or simplify your request.');
+        }
+
+        const results = inferenceResult.object;
 
         // Validate results structure
         if (!results) {

--- a/worker/api/controllers/agent/controller.ts
+++ b/worker/api/controllers/agent/controller.ts
@@ -184,7 +184,32 @@ export class CodingAgentController extends BaseController {
                 }
             });
         } catch (error) {
-            this.logger.error('Error starting code generation', error);
+            this.logger.error('Error starting code generation', {
+                error: error instanceof Error ? error.message : String(error),
+                stack: error instanceof Error ? error.stack : undefined
+            });
+
+            // Provide more specific error responses based on error type
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+            // Check for template/sandbox service errors
+            if (errorMessage.includes('template') || errorMessage.includes('Template') ||
+                errorMessage.includes('sandbox') || errorMessage.includes('Sandbox')) {
+                return CodingAgentController.createErrorResponse(
+                    `Template service error: ${errorMessage}`,
+                    502
+                );
+            }
+
+            // Check for configuration errors
+            if (errorMessage.includes('config') || errorMessage.includes('Config') ||
+                errorMessage.includes('environment') || errorMessage.includes('Environment')) {
+                return CodingAgentController.createErrorResponse(
+                    `Configuration error: ${errorMessage}`,
+                    500
+                );
+            }
+
             return CodingAgentController.handleError(error, 'start code generation');
         }
     }


### PR DESCRIPTION
- Add specific error handling in agent controller for template and sandbox service errors
- Return 502 status for external service failures instead of generic 500
- Improve logging with detailed error context and stack traces
- Add defensive error handling in getTemplateForQuery with better error messages
- Fix potential null pointer when executeInference fails after all retries
- Improve frontend error messages for better user experience